### PR TITLE
skip useless normalize()

### DIFF
--- a/index.glsl
+++ b/index.glsl
@@ -2,7 +2,7 @@ mat3 calcLookAtMatrix(vec3 origin, vec3 target, float roll) {
   vec3 rr = vec3(sin(roll), cos(roll), 0.0);
   vec3 ww = normalize(target - origin);
   vec3 uu = normalize(cross(ww, rr));
-  vec3 vv = normalize(cross(uu, ww));
+  vec3 vv = cross(uu, ww);
 
   return mat3(uu, vv, ww);
 }


### PR DESCRIPTION
Since `uu` & `ww` are already othogonal and normalized, we don't need to normalize the result of `cross(uu, ww)`